### PR TITLE
chore(deps-dev): bump p-timeout from 5.1.0 to 6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "form-data": "^4.0.0",
     "formdata-node": "^4.2.4",
     "mocha": "^9.1.3",
-    "p-timeout": "^5.0.0",
+    "p-timeout": "^6.1.1",
     "stream-consumers": "^1.0.1",
     "tsd": "^0.14.0",
     "xo": "^0.39.1"


### PR DESCRIPTION
### Description

In this pull request, the version of the "p-timeout" dependency in the package.json file is being updated from "^5.0.0" to "^6.1.1".

Changes:
- Updated the version of the "p-timeout" dependency in package.json from "^5.0.0" to "^6.1.1".